### PR TITLE
Adjusted Rapiko, Camerlengo, and Bullet artwork to 5px in height

### DIFF
--- a/data.rb
+++ b/data.rb
@@ -8,6 +8,8 @@ $palette = {
   'y' => 178,
   'd' => 22,
   'r' => 196,
+  'l' => 252,
+  'v' => 124,
 }
 
 # Rapiko's height should be <= 15
@@ -15,9 +17,9 @@ $palette = {
 $rapiko = %w[
   .w.w
   .w.w
-  wrwrw
-  wwwww
+  .wwvw
   .www
+  wwlwl
 ]
 
 # Camerlengo's height should be equal to Rapiko

--- a/data.rb
+++ b/data.rb
@@ -1,11 +1,9 @@
 # Fill in the blank with your name
-$author = "" # Your name
+$author = "chobishiba" # Your name
 
 # You can modify and add colors here
 $palette = {
   'w' => 231,
-  'p' => 217,
-  'b' => 232,
   'g' => 34,
   'y' => 178,
   'd' => 22,
@@ -15,42 +13,26 @@ $palette = {
 # Rapiko's height should be <= 15
 # Rapiko's fur color should be white
 $rapiko = %w[
-  ......www..ww
-  ......wpw..wp
-  ....wwwpwwwwpw
-  ...wwwwwwwwwwww
-  ...wwwwwbwwwwbw
-  ....wwwwwwwbwww
-  .....wwwwwwwww
-  .....pppppppppp
-  ....ppwwppppppww
-  ...wpppppppppp
-  .....www....www
+  .w.w
+  .w.w
+  wrwrw
+  wwwww
+  .www
 ]
 
 # Camerlengo's height should be equal to Rapiko
 $camerlengo = %w[
-  .
-  .
-  .
-  .
-  .............yyyyy
-  ............yyyddyy
-  ....ggggggggyyyyyyy
-  ...ggggggggggyyyyy
-  ..gggggggggggg
-  yygggggggggggg
-  ...yyy......yyy
+    .
+  ...yd
+  .ggyy
+  gggg
+  y..y
 ]
 
 # Bullet should be Ruby
 $bullet = %w[
-  .
-  .
-  ......rrrrrr
-  ....rrrrrrrrrr
-  ..rrrrrrrrrrrrrr..
-  ....rrrrrrrrrr
-  ......rrrrrr
-  ........rr
+  .rrr
+  rrrrr
+  .rrr
+  ..r
 ]


### PR DESCRIPTION
## Screenshot
<img width="384" height="143" alt="usakame_5px_2" src="https://github.com/user-attachments/assets/2638c2b5-f81c-4d43-9920-bdb57916af8d" />


## Changes
* All artworks adjusted to 5px or less  in height.
  * This artwork is a good fit for presentations with large fonts (e.g., Takahashi Method style).